### PR TITLE
feat: init a button_handler

### DIFF
--- a/components/button_handler/CMakeLists.txt
+++ b/components/button_handler/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "button_handler.c"
+                    INCLUDE_DIRS "."
+                    PRIV_REQUIRES driver freertos)

--- a/components/button_handler/button_handler.c
+++ b/components/button_handler/button_handler.c
@@ -1,0 +1,55 @@
+#include "button_handler.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
+
+#define LEFT_BUTTON_GPIO GPIO_NUM_9  // Change to your actual GPIO number
+#define RIGHT_BUTTON_GPIO GPIO_NUM_2 // Change to your actual GPIO number
+
+static const char *TAG = "ButtonHandler";
+
+static QueueHandle_t gpioLeftEventQueue = NULL;
+static button_callback_t leftButtonCallback = NULL;
+static button_callback_t rightButtonCallback = NULL;
+
+static void IRAM_ATTR gpioISRHandler(void* arg) {
+    uint32_t gpioNum = (uint32_t) arg;
+    xQueueSendFromISR(gpioLeftEventQueue, &gpioNum, NULL);
+}
+
+static void button_task(void* arg) {
+    int gpioNum;
+    while (1) {
+        if (xQueueReceive(gpioLeftEventQueue, &gpioNum, portMAX_DELAY)) {
+            // debounce
+            vTaskDelay(pdMS_TO_TICKS(50));
+
+            if (gpio_get_level(gpioNum) == 0) { 
+                ESP_LOGI(TAG, "Button press detected on GPIO %d", gpioNum);
+                if (leftButtonCallback) {
+                    leftButtonCallback(); 
+                }
+            }
+        }
+    }
+}
+
+void initLeftButtonHandler(button_callback_t callback) {
+    leftButtonCallback = callback;
+
+    gpio_config_t io_conf = {
+        .intr_type = GPIO_INTR_NEGEDGE,
+        .mode = GPIO_MODE_INPUT,
+        .pin_bit_mask = (1 << LEFT_BUTTON_GPIO),
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+    };
+    gpio_config(&io_conf);
+
+    gpioLeftEventQueue = xQueueCreate(10, sizeof(uint32_t));
+    xTaskCreate(button_task, "button_task", 2048, NULL, 10, NULL);
+
+    gpio_isr_handler_add(LEFT_BUTTON_GPIO, gpioISRHandler, (void*) LEFT_BUTTON_GPIO);
+}

--- a/components/button_handler/button_handler.h
+++ b/components/button_handler/button_handler.h
@@ -1,0 +1,9 @@
+#ifndef BUTTON_HANDLER_H
+#define BUTTON_HANDLER_H
+
+typedef void (*button_callback_t)(void);
+
+void initLeftButtonHandler(button_callback_t callback);
+void initRightButtonHandler(button_callback_t callback);
+
+#endif

--- a/components/mqtt_handler/CMakeLists.txt
+++ b/components/mqtt_handler/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "mqtt_handler.c"
                     INCLUDE_DIRS "."
-                    REQUIRES "mqtt")
+                    REQUIRES "mqtt" "status_led")

--- a/components/mqtt_handler/mqtt_handler.c
+++ b/components/mqtt_handler/mqtt_handler.c
@@ -1,17 +1,30 @@
 #include "mqtt_handler.h"
 #include "esp_log.h"
 #include "sdkconfig.h"
+#include <string.h>
+
+#include "status_led.h"
 
 static const char *TAG = "MQTT-Handler";
 
 static esp_mqtt_client_handle_t client = NULL;
 
+// helper function to copy data to a null-terminated string
+char *copy_to_cstring(const char *data, int len) {
+    char *buf = malloc(len + 1);
+    if (!buf) return NULL;
+    memcpy(buf, data, len);
+    buf[len] = '\0';
+    return buf;
+}
 
 // TODO: Perhaps we log the connected or disconnected state on the display?
 static void mqttEventHandlerCB(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data) {
     switch (event_id) {
         case MQTT_EVENT_CONNECTED:
             ESP_LOGI(TAG, "Connected to MQTT broker");
+
+            esp_mqtt_client_subscribe(client, MQTT_STATUS_LED_CMD_TOPIC, 1);
             break;
 
         case MQTT_EVENT_DISCONNECTED:
@@ -19,9 +32,24 @@ static void mqttEventHandlerCB(void *handler_args, esp_event_base_t base, int32_
             break;
 
         case MQTT_EVENT_DATA:
-            const char *str = (const char *)event_data;
-            ESP_LOGI(TAG, "Received data on topic %s", str);
-            // TODO: Here we handle incoming mqtt messages
+            // cast void pointer to type
+            esp_mqtt_event_handle_t event = (esp_mqtt_event_handle_t) event_data;
+
+            // copy the topic and data to null-terminated strings
+            char *topic = copy_to_cstring(event->topic, event->topic_len);
+            char *data = copy_to_cstring(event->data, event->data_len);
+
+            // check what topic we received
+
+            // status LED command topic
+            if (strcmp(topic, MQTT_STATUS_LED_CMD_TOPIC) == 0) {
+                receiveMQTTStatusLEDCommand(data);
+            }
+
+            // free the allocated memory for topic and data
+            free(topic);
+            free(data);
+
             break;
 
         default:

--- a/components/mqtt_handler/mqtt_handler.h
+++ b/components/mqtt_handler/mqtt_handler.h
@@ -3,6 +3,9 @@
 
 #include "mqtt_client.h"
 
+#define MQTT_STATUS_LED_TOPIC "status_led/state"
+#define MQTT_STATUS_LED_CMD_TOPIC "status_led/set"
+
 void startupMQTT(void);
 void mqttPublishText(const char *topic, const char *text);
 #endif

--- a/components/status_led/CMakeLists.txt
+++ b/components/status_led/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "status_led.c"
                     INCLUDE_DIRS "."
-                    PRIV_REQUIRES "driver")
+                    PRIV_REQUIRES "driver" "mqtt_handler")

--- a/components/status_led/status_led.c
+++ b/components/status_led/status_led.c
@@ -9,8 +9,6 @@
 
 static const char *TAG = "Status LED";
 
-#define MQTT_STATUS_LED_TOPIC "status_led/state"
-
 static bool currentStatusLEDState = false; // default state is off
 
 void writeMQTTStatusLED(int statusLEDState) {
@@ -40,4 +38,15 @@ void initStatusLED() {
     gpio_config(&statusLEDConf);
     
     writeStatusLED(currentStatusLEDState); // Initialize the LED to the default state
+}
+
+// receive null terminated string data from MQTT and set the status LED accordingly
+void receiveMQTTStatusLEDCommand(const char *data) {
+    if (strcmp(data, "ON") == 0) {
+        writeStatusLED(true);
+    } else if (strcmp(data, "OFF") == 0) {
+        writeStatusLED(false);
+    } else {
+        ESP_LOGW(TAG, "Received unknown command for Status LED: %s", data);
+    }
 }

--- a/components/status_led/status_led.c
+++ b/components/status_led/status_led.c
@@ -1,13 +1,32 @@
 #include "status_led.h"
 
+#include <stdbool.h>
 #include "esp_log.h"
 #include "driver/gpio.h"
+#include "mqtt_handler.h"
 
 #define STATUS_LED_GPIO GPIO_NUM_0
 
 static const char *TAG = "Status LED";
 
-static int statusLEDState = 0; // start with LED off
+#define MQTT_STATUS_LED_TOPIC "status_led/state"
+
+static bool currentStatusLEDState = false; // default state is off
+
+void writeMQTTStatusLED(int statusLEDState) {
+    mqttPublishText(MQTT_STATUS_LED_TOPIC, statusLEDState ? "ON" : "OFF");
+}
+
+void writeStatusLED(int statusLEDState) {
+    currentStatusLEDState = statusLEDState;
+    gpio_set_level(STATUS_LED_GPIO, statusLEDState);
+    ESP_LOGI(TAG, "Status LED wrote to %s!", statusLEDState ? "ON" : "OFF");
+    writeMQTTStatusLED(statusLEDState);
+}
+
+void toggleStatusLED() {
+    writeStatusLED(!currentStatusLEDState);
+}
 
 void initStatusLED() {
     gpio_config_t statusLEDConf = {
@@ -20,11 +39,5 @@ void initStatusLED() {
     
     gpio_config(&statusLEDConf);
     
-    gpio_set_level(STATUS_LED_GPIO, statusLEDState);
-}
-
-void toggleStatusLED() {
-    statusLEDState = !statusLEDState;
-    gpio_set_level(STATUS_LED_GPIO, statusLEDState);
-    ESP_LOGI(TAG, "Status LED toggled to %s!", statusLEDState ? "ON" : "OFF");
+    writeStatusLED(currentStatusLEDState); // Initialize the LED to the default state
 }

--- a/components/status_led/status_led.h
+++ b/components/status_led/status_led.h
@@ -3,5 +3,6 @@
 
 void initStatusLED();
 void toggleStatusLED();
+void receiveMQTTStatusLEDCommand(const char *data);
 
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -1,19 +1,17 @@
-#include <stdio.h>
+#include "driver/gpio.h"
 
 #include "mqtt_handler.h"
 #include "wifi_handler.h"
 #include "status_led.h"
+#include "button_handler.h"
 
 void app_main(void)
 {
+    gpio_install_isr_service(0);
+
     startupWiFi();
     startupMQTT();
-    initStatusLED();
 
-    while (1)
-    {
-        toggleStatusLED();
-        vTaskDelay(pdMS_TO_TICKS(1000)); // Toggle every second
-    }
-    
+    initStatusLED();
+    initLeftButtonHandler(toggleStatusLED);
 }


### PR DESCRIPTION
Added a button_handler - where a left-button click can be initialized with an ISR and a task, that checks a event-queue. 
On init a callback can be specified.

Put the status-LED-toggle on the callback and write the status-led to mqtt.